### PR TITLE
Read version w/o importing dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,6 @@ for help on creating Windows executables.
 from distutils.core import setup
 import glob
 import os.path
-from transitfeed import __version__ as VERSION
 
 try:
   import py2exe
@@ -34,6 +33,12 @@ try:
 except ImportError as e:
   # Won't be able to generate win32 exe
   has_py2exe = False
+  
+with open('transitfeed/version.py') as fid:
+  for line in fid:
+      if line.startswith('__version__'):
+        VERSION = line.strip().split()[-1][1:-1]
+        break
 
 
 # py2exe doesn't automatically include pytz dependency because it is optional


### PR DESCRIPTION
`pip install` currently fails w/
```
(transitfeed) ➜  model git:(ground_truth) ✗ pip install git+https://github.com/OriginalPenguin/transitfeed.git#egg=transitfeed
Collecting transitfeed from git+https://github.com/OriginalPenguin/transitfeed.git#egg=transitfeed
  Cloning https://github.com/OriginalPenguin/transitfeed.git to /private/var/folders/kb/5p7n5tds71v3rsmjtjqm2w4r0000gn/T/pip-build-7rlum0uh/transitfeed
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/private/var/folders/kb/5p7n5tds71v3rsmjtjqm2w4r0000gn/T/pip-build-7rlum0uh/transitfeed/setup.py", line 29, in <module>
        from transitfeed import __version__ as VERSION
      File "/private/var/folders/kb/5p7n5tds71v3rsmjtjqm2w4r0000gn/T/pip-build-7rlum0uh/transitfeed/transitfeed/__init__.py", line 67, in <module>
        from .util import *
      File "/private/var/folders/kb/5p7n5tds71v3rsmjtjqm2w4r0000gn/T/pip-build-7rlum0uh/transitfeed/transitfeed/util.py", line 20, in <module>
        from past.builtins import cmp
    ModuleNotFoundError: No module named 'past'
```
This import is a side effect of importing `transitfeed.__version__`. This is an alternative pattern I stole from
https://github.com/scikit-image/scikit-image/blob/master/setup.py which reads the file directly rather than actually importing it so that no other dependencies get pulled in during install.